### PR TITLE
include bug number in job name

### DIFF
--- a/scripts/tatt
+++ b/scripts/tatt
@@ -175,6 +175,8 @@ if myJob.packageList is not None and len(myJob.packageList) > 0:
         myJob.name = options.jobname
     elif options.infile:
         myJob.name = options.infile
+    elif options.bugnum:
+        myJob.name = myJob.packageList[0].packageName() + '-' + options.bugnum
     else:
         myJob.name = myJob.packageList[0].packageName()
     print ("Jobname: " + myJob.name)


### PR DESCRIPTION
This makes the script name unique, which helps if the same packages are affected e.g. by stabilization and keywording, or if different python versions (2, 3) are requested for stabilization.

Fixes kensington/tatt#6.