### PR TITLE
make use and revdep scripts more compact

### DIFF
--- a/scripts/tatt
+++ b/scripts/tatt
@@ -5,6 +5,7 @@ from subprocess import *
 import sys
 import re
 import os
+import portage
 import base64
 import requests
 
@@ -182,8 +183,26 @@ if myJob.packageList is not None and len(myJob.packageList) > 0:
     print ("Jobname: " + myJob.name)
     ## Determine jobtype
 
+    port = portage.db[portage.root]["porttree"].dbapi
+
+    filteredPackages = []
     for p in myJob.packageList:
         print("Found the following package atom : " + p.packageString())
+        # check if the package already has the needed keywords
+        if config['arch']:
+            kw = port.aux_get(p.packageString()[1:], ["KEYWORDS"])
+            if len(kw) > 0:
+                kwl = kw[0].split()
+                try:
+                    kwl.index(config['arch'])
+                    # the list of keywords in portage already contains the target
+                    # keyword, skip this package
+                    print("\talready stable")
+                    continue
+                except ValueError:
+                    filteredPackages.append(p)
+
+    myJob.packageList = filteredPackages
 
     # Unmasking:
     try:

--- a/tatt/scriptwriter.py
+++ b/tatt/scriptwriter.py
@@ -2,7 +2,6 @@
 
 import random
 import os
-import portage
 import sys
 
 from .usecombis import findUseFlagCombis
@@ -50,8 +49,6 @@ def writeusecombiscript(job, config):
     # config is a tatt configuration
     useheader = scriptTemplate(job.name, config, "use-header")
 
-    port = portage.db[portage.root]["porttree"].dbapi
-
     outfilename = (job.name + "-useflags.sh")
     reportname = (job.name + ".report")
     if os.path.isfile(outfilename):
@@ -59,19 +56,6 @@ def writeusecombiscript(job, config):
     outfile = open(outfilename, 'w')
     outfile.write(useheader)
     for p in job.packageList:
-        # check if the package already has the needed keywords
-        if config['arch']:
-            kw = port.aux_get(p.packageString()[1:], ["KEYWORDS"])
-            if len(kw) > 0:
-                kwl = kw[0].split()
-                try:
-                    kwl.index(config['arch'])
-                    # the list of keywords in portage already contains the target
-                    # keyword, skip this package
-                    continue
-                except ValueError:
-                    pass
-
         outfile.write("# Code for " + p.packageCatName() + "\n")
         outfile.write(useCombiTestString(job.name, p, config))
         outfile.write("echo >> " + reportname + "\n")

--- a/tatt/scriptwriter.py
+++ b/tatt/scriptwriter.py
@@ -74,6 +74,7 @@ def writeusecombiscript(job, config):
 
         outfile.write("# Code for " + p.packageCatName() + "\n")
         outfile.write(useCombiTestString(job.name, p, config))
+        outfile.write("echo >> " + reportname + "\n")
     # Note: fchmod needs the filedescriptor which is an internal
     # integer retrieved by fileno().
     os.fchmod(outfile.fileno(), 0o744)  # rwxr--r--

--- a/templates/revdep-header
+++ b/templates/revdep-header
@@ -15,6 +15,10 @@ function tatt_pkg_error
     echo "USE='${USE}' : USE dependencies not satisfied (probably) for ${1:?}" >> @@REPORTFILE@@
   elif [[ "${eout}" =~ keyword\ changes ]]; then
     echo "USE='${USE}' : unkeyworded dependencies (probably) for ${1:?}" >> @@REPORTFILE@@
+  elif [[ "${eout}" =~ Error:\ circular\ dependencies: ]]; then
+    echo "USE='${USE}' : circular dependencies (probably) for ${1:?}" >> @@REPORTFILE@@
+  elif [[ "${eout}" =~ \[blocks\ B ]]; then
+    echo "USE='${USE}' : blocked packages (probably) for ${1:?}" >> @@REPORTFILE@@
   else
     echo "USE='${USE}' FEATURES='${FEATURES}' failed for ${1:?}" >> @@REPORTFILE@@
   fi

--- a/templates/revdep-header
+++ b/templates/revdep-header
@@ -2,3 +2,21 @@
 # Reverse dependency testing for @@JOB@@
 
 trap "echo 'signal captured, exiting the entire script...'; exit" SIGHUP SIGINT SIGTERM 
+
+function tatt_pkg_error
+{
+  local eout=${2}
+
+  echo "${eout}"
+
+  if [[ "${eout}" =~ REQUIRED_USE ]] ; then
+    echo "USE='${USE}' : REQUIRED_USE not satisfied (probably) for ${1:?}" >> @@REPORTFILE@@
+  elif [[ "${eout}" =~ USE\ changes ]] ; then
+    echo "USE='${USE}' : USE dependencies not satisfied (probably) for ${1:?}" >> @@REPORTFILE@@
+  elif [[ "${eout}" =~ keyword\ changes ]]; then
+    echo "USE='${USE}' : unkeyworded dependencies (probably) for ${1:?}" >> @@REPORTFILE@@
+  else
+    echo "USE='${USE}' FEATURES='${FEATURES}' failed for ${1:?}" >> @@REPORTFILE@@
+  fi
+}
+

--- a/templates/revdep-snippet
+++ b/templates/revdep-snippet
@@ -1,16 +1,6 @@
 eout=$( @@FEATURES@@  @@USE@@ emerge -1 @@EMERGEOPTS@@ @@CPV@@ 2>&1 1>/dev/tty )
 if [[ $? == 0 ]] ; then
   echo "@@FEATURES@@ @@USE@@ succeeded for @@CPV@@" >> @@REPORTFILE@@
-elif [[ "${eout}" =~ REQUIRED_USE ]] ; then
-  echo "${eout}"
-  echo "@@CPV@@ : REQUIRED_USE not satisfied (probably) for @@CPV@@" >> @@REPORTFILE@@
-elif [[ "${eout}" =~ USE\ changes ]] ; then
-  echo "${eout}"
-  echo "@@CPV@@ : USE dependencies not satisfied (probably) for @@CPV@@" >> @@REPORTFILE@@
-elif [[ "${eout}" =~ keyword\ changes ]]; then
-  echo "${eout}"
-  echo "@@USE@@ : unkeyworded dependencies (probably) for @@CPV@@" >> @@REPORTFILE@@
 else
-  echo "${eout}"
-  echo "@@FEATURES@@ failed for @@CPV@@" >> @@REPORTFILE@@
+  @@USE@@ @@FEATURES@@ tatt_pkg_error "@@CPV@@" "${eout}"
 fi

--- a/templates/use-header
+++ b/templates/use-header
@@ -15,6 +15,10 @@ function tatt_pkg_error
     echo "USE='${USE}' : USE dependencies not satisfied (probably) for ${1:?}" >> @@REPORTFILE@@
   elif [[ "${eout}" =~ keyword\ changes ]]; then
     echo "USE='${USE}' : unkeyworded dependencies (probably) for ${1:?}" >> @@REPORTFILE@@
+  elif [[ "${eout}" =~ Error:\ circular\ dependencies: ]]; then
+    echo "USE='${USE}' : circular dependencies (probably) for ${1:?}" >> @@REPORTFILE@@
+  elif [[ "${eout}" =~ \[blocks\ B ]]; then
+    echo "USE='${USE}' : blocked packages (probably) for ${1:?}" >> @@REPORTFILE@@
   else
     echo "USE='${USE}' FEATURES='${FEATURES}' failed for ${1:?}" >> @@REPORTFILE@@
   fi

--- a/templates/use-header
+++ b/templates/use-header
@@ -2,3 +2,21 @@
 #USE-Flag build tests for job @@JOB@@
 
 trap "echo 'signal captured, exiting the entire script...'; exit" SIGHUP SIGINT SIGTERM
+
+function tatt_pkg_error
+{
+  local eout=${2}
+
+  echo "${eout}"
+
+  if [[ "${eout}" =~ REQUIRED_USE ]] ; then
+    echo "USE='${USE}' : REQUIRED_USE not satisfied (probably) for ${1:?}" >> @@REPORTFILE@@
+  elif [[ "${eout}" =~ USE\ changes ]] ; then
+    echo "USE='${USE}' : USE dependencies not satisfied (probably) for ${1:?}" >> @@REPORTFILE@@
+  elif [[ "${eout}" =~ keyword\ changes ]]; then
+    echo "USE='${USE}' : unkeyworded dependencies (probably) for ${1:?}" >> @@REPORTFILE@@
+  else
+    echo "USE='${USE}' FEATURES='${FEATURES}' failed for ${1:?}" >> @@REPORTFILE@@
+  fi
+}
+

--- a/templates/use-snippet
+++ b/templates/use-snippet
@@ -1,16 +1,6 @@
 eout=$( @@USE@@ @@FEATURES@@ emerge -1 @@EMERGEOPTS@@ @@CPV@@ 2>&1 1>/dev/tty )
 if [[ $? == 0 ]] ; then
   echo "@@USE@@ @@FEATURES@@ succeeded for @@CPV@@" >> @@REPORTFILE@@
-elif [[ "${eout}" =~ REQUIRED_USE ]] ; then
-  echo "${eout}"
-  echo "@@USE@@ : REQUIRED_USE not satisfied (probably) for @@CPV@@" >> @@REPORTFILE@@
-elif [[ "${eout}" =~ USE\ changes ]] ; then
-  echo "${eout}"
-  echo "@@USE@@ : USE dependencies not satisfied (probably) for @@CPV@@" >> @@REPORTFILE@@
-elif [[ "${eout}" =~ keyword\ changes ]]; then
-  echo "${eout}"
-  echo "@@USE@@ : unkeyworded dependencies (probably) for @@CPV@@" >> @@REPORTFILE@@
 else
-  echo "${eout}"
-  echo "@@USE@@ @@FEATURES@@ failed for @@CPV@@" >> @@REPORTFILE@@
+  @@USE@@ @@FEATURES@@ tatt_pkg_error "@@CPV@@" "${eout}"
 fi


### PR DESCRIPTION
 * filter out already stable packages earlier and also for revdeps
 * use shell function to handle build errors
 * also catch circular dependencies and blocked packages with explicit messages