### PR TITLE
use Portage and Gentoolkit API

### DIFF
--- a/scripts/tatt
+++ b/scripts/tatt
@@ -6,6 +6,7 @@ import sys
 import re
 import os
 import portage
+from portage.dep import dep_getcpv
 import base64
 import requests
 
@@ -195,7 +196,7 @@ if myJob.packageList is not None and len(myJob.packageList) > 0:
         for p in myJob.packageList:
             print("Found the following package atom : " + p.packageString())
             # check if the package already has the needed keywords
-            kw = port.aux_get(p.packageString()[1:], ["KEYWORDS"])
+            kw = port.aux_get(dep_getcpv(p.packageString()), ["KEYWORDS"])
             if len(kw) > 0:
                 kwl = kw[0].split()
                 try:

--- a/tatt/gentooPackage.py
+++ b/tatt/gentooPackage.py
@@ -1,7 +1,7 @@
 """Module for easy access to portage's atom syntax """
 
 import re
-from portage.dep import dep_getcpv
+from portage.dep import dep_getcpv, dep_getkey, isvalidatom
 
 class gentooPackage(object):
     """A Gentoo package consists of:
@@ -12,28 +12,13 @@ class gentooPackage(object):
 
     def __init__(self, st):
         """An atom is initialized from an atom string"""
-        st = dep_getcpv(st)
-        slashparts = st.split("/")
+        if not isvalidatom(st):
+            st = '=' + st
+        cp = dep_getkey(st)
+        self.ver = dep_getcpv(st)[len(cp) + 1:] # +1 to strip the leading '-'
+        slashparts = cp.split("/")
         self.category = slashparts[0]
-        minusparts = slashparts[1].split("-")
-        self.ver = ""
-        if len (minusparts) == 1:
-            # No version given
-            self.name=slashparts[1]
-        else:
-            # Parse the name-version part
-            self.name=""
-            while 1:
-                p = minusparts.pop(0)
-                # Try a number after a '-'
-                if re.match('[0-9]+', p):
-                    # Version starts here:
-                    self.ver = "-".join([p] + minusparts)
-                    break
-                else:
-                    # Append back to name
-                    if self.name=="": self.name = p
-                    else : self.name = "-".join([self.name, p])
+        self.name = slashparts[1]
 
     def packageName(self):
         """Returns the package name without category"""

--- a/tatt/gentooPackage.py
+++ b/tatt/gentooPackage.py
@@ -1,6 +1,7 @@
 """Module for easy access to portage's atom syntax """
 
 import re
+from portage.dep import dep_getcpv
 
 class gentooPackage(object):
     """A Gentoo package consists of:
@@ -11,7 +12,7 @@ class gentooPackage(object):
 
     def __init__(self, st):
         """An atom is initialized from an atom string"""
-        if st[0] == '=': st = st[1:]
+        st = dep_getcpv(st)
         slashparts = st.split("/")
         self.category = slashparts[0]
         minusparts = slashparts[1].split("-")

--- a/tatt/scriptwriter.py
+++ b/tatt/scriptwriter.py
@@ -2,6 +2,7 @@
 
 import random
 import os
+import portage
 import sys
 
 from .usecombis import findUseFlagCombis
@@ -27,13 +28,13 @@ def scriptTemplate(jobname, config, filename):
     snippet = snippet.replace("@@REPORTFILE@@", reportname)
     return snippet
 
-def useCombiTestString(jobname, pack, config):
+def useCombiTestString(jobname, pack, config, port):
     """ Build with diffent useflag combis """
     usesnippet = scriptTemplate(jobname, config, "use-snippet")
 
     s = "" # This will contain the resulting string
     usesnippet = usesnippet.replace("@@CPV@@", pack.packageString() )
-    usecombis = findUseFlagCombis (pack, config)
+    usecombis = findUseFlagCombis (pack, config, port)
     for uc in usecombis:
         localsnippet = usesnippet.replace("@@USE@@", uc)
         localsnippet = localsnippet.replace("@@FEATURES@@", "")
@@ -55,9 +56,10 @@ def writeusecombiscript(job, config):
         print("WARNING: Will overwrite " + outfilename)
     outfile = open(outfilename, 'w')
     outfile.write(useheader)
+    port = portage.db[portage.root]["porttree"].dbapi
     for p in job.packageList:
         outfile.write("# Code for " + p.packageCatName() + "\n")
-        outfile.write(useCombiTestString(job.name, p, config))
+        outfile.write(useCombiTestString(job.name, p, config, port))
         outfile.write("echo >> " + reportname + "\n")
     # Note: fchmod needs the filedescriptor which is an internal
     # integer retrieved by fileno().

--- a/tatt/tinderbox.py
+++ b/tatt/tinderbox.py
@@ -12,6 +12,7 @@ from subprocess import *
 import random
 
 from .gentooPackage import gentooPackage as gP
+from portage.dep import isvalidatom
 
 ## TODO: Make the number of rdeps to sample a config option
 ## Pass the config on to this function:
@@ -59,7 +60,8 @@ def stablerdeps (package, config):
     d = dict([])
     for s in splitlist:
         # Saves necessary useflags under package names, removing duplicates.
-        d[gP(s[0]).packageCatName()] = s[1]
+        if isvalidatom('=' + s[0]):
+            d[gP(s[0]).packageCatName()] = s[1]
     outlist2 = [[k, d[k]] for k in list(d.keys())]
     outlist = []
     # outlist2 is set up at this point.  It contains all candidates.  To cut it down we sample

--- a/tatt/usecombis.py
+++ b/tatt/usecombis.py
@@ -3,7 +3,7 @@
 import random
 import re
 import math
-from portage.dep import check_required_use
+from portage.dep import check_required_use, dep_getcpv
 from subprocess import *
 
 from .tool import unique
@@ -18,7 +18,7 @@ def findUseFlagCombis (package, config, port):
     Generate combinations of use flags to test
     The output will be a list each containing a ready to use USE=... string
     """
-    uselist = sorted(reduce_flags(get_flags(package.packageString()[1:])))
+    uselist = sorted(reduce_flags(get_flags(dep_getcpv(package.packageString()))))
     # The uselist could have duplicates due to slot-conditional
     # output of equery
     uselist=unique(uselist)
@@ -43,7 +43,7 @@ def findUseFlagCombis (package, config, port):
         swlist = list(range(2**len(uselist)))
 
     usecombis=[]
-    ruse = " ".join(port.aux_get(package.packageString()[1:], ["REQUIRED_USE"]))
+    ruse = " ".join(port.aux_get(dep_getcpv(package.packageString()), ["REQUIRED_USE"]))
     for sw in swlist:
         mod = []
         act = [] # check_required_use doesn't like -flag entries

--- a/tatt/usecombis.py
+++ b/tatt/usecombis.py
@@ -7,6 +7,7 @@ from portage.dep import check_required_use
 from subprocess import *
 
 from .tool import unique
+from gentoolkit.flag import get_flags, reduce_flags
 
 def all_valid_flags(flag):
     return True
@@ -17,9 +18,7 @@ def findUseFlagCombis (package, config, port):
     Generate combinations of use flags to test
     The output will be a list each containing a ready to use USE=... string
     """
-    uses=Popen('equery -C uses '+package.packageString()+' | cut -f 1 | cut -c 2-40 | xargs',
-               shell=True, stdout=PIPE).communicate()[0].decode('utf-8')
-    uselist=uses.split()
+    uselist = sorted(reduce_flags(get_flags(package.packageString()[1:])))
     # The uselist could have duplicates due to slot-conditional
     # output of equery
     uselist=unique(uselist)


### PR DESCRIPTION
This replaces some custom code with the functions from the portage API. It also now checks for REQUIRED_USE before even writing those lines to the test scripts, so no invalid use flag combinations should show up in the scripts anymore. The call to equery is replaced with a direct call to the gentoolkit API, which gives the same results.

Closes #10.
Closes #28.
Closes #35.