### PR TITLE
templates: Match p.g.o syntax

### DIFF
--- a/templates/commit-snippet-2
+++ b/templates/commit-snippet-2
@@ -2,8 +2,6 @@
 pushd @@CP@@ > /dev/null
 
 repoman -d full || exit 1
-repoman -m "@@CP@@: @@NEWKEYWORD@@ stable
-
-Gentoo-bug: @@BUG@@" commit || exit 1
+repoman -m "@@CP@@: @@NEWKEYWORD@@ stable (bug #@@BUG@@)" commit || exit 1
 
 popd > /dev/null


### PR DESCRIPTION
I specifically opted for the p.g.o syntax and decided against the [GLEP 66 syntax](https://www.gentoo.org/glep/glep-0066.html#commit-messages) to avoid bug spam on commit because the dedicated success script will do the bugzilla work.