### PR TITLE
fix endless loop with invalid use flags

### DIFF
--- a/tatt/usecombis.py
+++ b/tatt/usecombis.py
@@ -55,6 +55,7 @@ def findUseFlagCombis (package, config, port):
             if r in rnds:
                 # already checked
                 continue
+            rnds.add(r)
 
             if not check_uses(ruse, uselist, r, package):
                 # invalid combination


### PR DESCRIPTION
The set of already tested use combinations was never filled, so the loop may run forever.