### PR TITLE
tatt_functions.sh: keep original use flags when doing initial minimal build

### DIFF
--- a/templates/tatt_functions.sh
+++ b/templates/tatt_functions.sh
@@ -49,7 +49,7 @@ function tatt_test_pkg
 
 	# Do a first pass to avoid circular dependencies
 	# --onlydeps should mean we're avoiding (too much) duplicate work
-	USE="minimal -doc" emerge --onlydeps -q1 --with-test-deps ${TATT_EMERGEOPTS} "${1:?}"
+	USE="${USE} minimal -doc" emerge --onlydeps -q1 --with-test-deps ${TATT_EMERGEOPTS} "${1:?}"
 
     if ! emerge --onlydeps -q1 --with-test-deps ${TATT_EMERGEOPTS} "${1:?}"; then
       echo "merging test dependencies of ${1} failed" >> "${TATT_REPORTFILE}"


### PR DESCRIPTION
Otherwise missing python_targets_* or ruby_targets_* may cause the build to fail early.

The whole "build tests first" was introduced in bc513236909c9efb11a4c6ec3c6eef85b72f4265 to catch exactly such things where the packages are somewhat broken.